### PR TITLE
Update Traefik version to v3.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   traefik:
-    image: traefik:v3.3
+    image: traefik:v3.6
     hostname: proxy
     container_name: mbyte_proxy
     command: --api.insecure=true --providers.docker


### PR DESCRIPTION
Fixes a regression introduced by updating to Docker Engine v25.0+, which rejects older API versions.

The client was attempting to use API 1.24, resulting in errors such as: client version 1.24 is too old. Minimum supported API version is 1.30...

[My issue fixed](https://community.traefik.io/t/traefik-stops-working-it-uses-old-api-version-1-24/29019/19) 

@jayblanc 