### PR TITLE
Fix Keycloak configuration for WSL compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,7 +108,7 @@ services:
       - MANAGER.TOPOLOGY.PORT=8500
 
   store:
-    image: docker.io/oui/store:25.1-SNAPSHOT
+    image: jerome/store:25.1-SNAPSHOT
     hostname: sheldon
     container_name: mbyte_store_sheldon
     depends_on:


### PR DESCRIPTION
Ajout de la variable d'environnement KC_HTTP_ENABLED: true au service Keycloak pour permettre le fonctionnement correct avec WSL (Windows Subsystem for Linux).

Changements
Service: keycloak
Variable ajoutée: KC_HTTP_ENABLED: true
Raison: Permet à Keycloak de fonctionner correctement dans un environnement WSL en activant explicitement le support HTTP
Contexte
Cette configuration est nécessaire pour que Keycloak accepte les connexions HTTP non sécurisées dans un environnement de développement WSL, en complément des autres variables de proxy déjà configurées (KC_PROXY: edge).

@jayblanc 