### PR TITLE
feat: add file versioning system (history, restore, auto-version)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,8 @@ services:
       - db
       - traefik
       - keycloak
+    group_add:
+      - "984"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:rw
     extra_hosts:
@@ -131,6 +133,7 @@ services:
       - MANAGER_TOPOLOGY_HOST=consul
       - MANAGER_TOPOLOGY_PORT=8500
       - MANAGER_INSTANCE=mbyte.fr
+      - MANAGER_RUNTIME_DOCKER_SERVER=unix:///var/run/docker.sock
 
   gui:
     image: mbyte/gui:26.2-SNAPSHOT

--- a/gui/src/assets/i18n/en.json
+++ b/gui/src/assets/i18n/en.json
@@ -4,7 +4,8 @@
     "now": "just now",
     "user": "User",
     "unknown": "Unknown",
-    "testNotification": "Test notification via CoreUI."
+    "testNotification": "Test notification via CoreUI.",
+    "cancel": "Cancel"
   },
   "auth": {
     "logout": "Sign out"
@@ -87,6 +88,7 @@
       "fileLabel": "File",
       "confirm": "Confirm",
       "cancel": "Cancel"
-    }
+    },
+    "fileExistsError": "The file \"{{fileName}}\" already exists. Please rename it or delete the existing file manually."
   }
 }

--- a/gui/src/assets/i18n/fr.json
+++ b/gui/src/assets/i18n/fr.json
@@ -1,10 +1,11 @@
 {
   "common": {
     "appName": "mbyte",
-    "now": "à l’instant",
+    "now": "à l'instant",
     "user": "Utilisateur",
     "unknown": "Inconnu",
-    "testNotification": "Notification de test via CoreUI."
+    "testNotification": "Notification de test via CoreUI.",
+    "cancel": "Annuler"
   },
   "auth": {
     "logout": "Se délogger"
@@ -86,6 +87,7 @@
       "fileLabel": "Fichier",
       "confirm": "Confirmer",
       "cancel": "Annuler"
-    }
+    },
+    "fileExistsError": "Le fichier \"{{fileName}}\" existe déjà. Veuillez le renommer ou supprimer l'ancien fichier manuellement."
   }
 }

--- a/gui/src/javascript/api/useStoreApi.ts
+++ b/gui/src/javascript/api/useStoreApi.ts
@@ -30,8 +30,10 @@ export function useStoreApi(tokenProvider: TokenProvider, baseUrlOverride?: stri
         return await fn(...args)
       } catch (err: any) {
         const msg = err?.message ?? String(err)
-        // Dispatch a global event so `App.tsx` can show a toast
-        globalThis.dispatchEvent(new CustomEvent('mbyte-toast', { detail: { message: msg } }))
+        // Don't show toast for "already-exists" errors — handled by the UI
+        if (!msg.includes('already-exists')) {
+          globalThis.dispatchEvent(new CustomEvent('mbyte-toast', { detail: { message: msg } }))
+        }
         throw err
       }
     }) as T

--- a/gui/src/javascript/components/store/ConfirmUpdateModal.tsx
+++ b/gui/src/javascript/components/store/ConfirmUpdateModal.tsx
@@ -1,0 +1,30 @@
+import { CModal, CModalHeader, CModalTitle, CModalBody, CModalFooter, CButton } from '@coreui/react'
+
+type ConfirmUpdateModalProps = {
+  visible: boolean
+  fileName: string
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function ConfirmUpdateModal({ visible, fileName, onConfirm, onCancel }: ConfirmUpdateModalProps) {
+  return (
+    <CModal visible={visible} onClose={onCancel}>
+      <CModalHeader>
+        <CModalTitle>Fichier existant</CModalTitle>
+      </CModalHeader>
+      <CModalBody>
+        <p>Le fichier "{fileName}" existe déjà sur le serveur. Voulez-vous sauvegarder une nouvelle version ?</p>
+        <p className="text-muted small">Le contenu sera enregistré comme nouvelle version dans l'historique.</p>
+      </CModalBody>
+      <CModalFooter>
+        <CButton color="secondary" onClick={onCancel}>
+          Annuler
+        </CButton>
+        <CButton color="primary" onClick={onConfirm}>
+          Sauvegarder la version
+        </CButton>
+      </CModalFooter>
+    </CModal>
+  )
+}

--- a/gui/src/javascript/components/store/NavigationBar.tsx
+++ b/gui/src/javascript/components/store/NavigationBar.tsx
@@ -1,6 +1,6 @@
 import { CButton } from '@coreui/react'
 import { CIcon } from '@coreui/icons-react'
-import { cilGrid, cilList, cilHome, cilInfo, cilFolder, cilCloudUpload } from '@coreui/icons'
+import { cilGrid, cilList, cilHome, cilInfo, cilFolder, cilCloudUpload, cilHistory } from '@coreui/icons'
 import { useTranslation } from 'react-i18next'
 
 type BreadcrumbItemInline = { id?: string, name: string }
@@ -11,6 +11,8 @@ type NavigationBarProps = Readonly<{
   setViewMode: (m: 'table' | 'grid') => void
   detailVisible: boolean
   toggleDetail: () => void
+  historyVisible: boolean
+  toggleHistory: () => void
   setCurrentPath: (p: BreadcrumbItemInline[]) => void
   // optional callback for navigation (parent can update the URL)
   onNavigate?: (folderId?: string) => void
@@ -18,7 +20,7 @@ type NavigationBarProps = Readonly<{
   onUploadFile?: () => void
 }>
 
-export function NavigationBar({ breadcrumb, viewMode, setViewMode, detailVisible, toggleDetail, setCurrentPath, onNavigate, onCreateFolder, onUploadFile }: NavigationBarProps) {
+export function NavigationBar({ breadcrumb, viewMode, setViewMode, detailVisible, toggleDetail, historyVisible, toggleHistory, setCurrentPath, onNavigate, onCreateFolder, onUploadFile }: NavigationBarProps) {
   const { t } = useTranslation()
 
   return (
@@ -77,6 +79,9 @@ export function NavigationBar({ breadcrumb, viewMode, setViewMode, detailVisible
 
         <CButton color={detailVisible ? 'primary' : 'light'} size="sm" onClick={toggleDetail} title={detailVisible ? 'Hide details' : 'Show details'}>
           <CIcon icon={cilInfo} />
+        </CButton>
+        <CButton color={historyVisible ? 'primary' : 'light'} size="sm" onClick={toggleHistory} title="Historique des versions">
+          <CIcon icon={cilHistory} />
         </CButton>
       </div>
     </div>

--- a/gui/src/javascript/pages/StorePage.tsx
+++ b/gui/src/javascript/pages/StorePage.tsx
@@ -1,21 +1,34 @@
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useState, useRef, useCallback } from 'react'
 import { CContainer } from '@coreui/react'
 import { NavigationBar } from '../components/store/NavigationBar'
 import { BrowserArea } from '../components/store/BrowserArea'
 import { InfoPanel } from '../components/store/InfoPanel'
 import { CreateModal } from '../components/store/CreateModal'
+import { ConfirmUpdateModal } from '../components/store/ConfirmUpdateModal'
 import Node from '../api/entities/Node'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useAccessToken } from '../auth/useAccessToken'
 import { useStoreApi } from '../api/useStoreApi'
 import { useManagerStatus } from '../auth/useManagerStatus'
 import { apiConfig } from '../api/apiConfig'
+import { useProfile } from '../auth/useProfile'
+import { fetchWithAuth } from '../api/fetchWithAuth'
+import {
+  useAutoVersioning,
+  emitFileSaved,
+  emitVersionRestored,
+  VersionHistoryPanel,
+  RestoreConfirmModal,
+  FileVersion,
+  type FetchFn,
+} from '../versioning'
 
 type BreadcrumbItem = { id?: string, name: string }
 
 export function StorePage() {
   const [viewMode, setViewMode] = useState<'table' | 'grid'>('table')
   const [detailVisible, setDetailVisible] = useState(true)
+  const [historyVisible, setHistoryVisible] = useState(false)
   const [currentPath, setCurrentPath] = useState<BreadcrumbItem[]>([{ id: undefined, name: '/' }])
   const [nodes, setNodes] = useState<Node[]>([])
   const [selected, setSelected] = useState<Node | null>(null)
@@ -23,16 +36,29 @@ export function StorePage() {
   const [reloadKey, setReloadKey] = useState(0)
   const [showCreateModal, setShowCreateModal] = useState(false)
   const [modalType, setModalType] = useState<'folder' | 'file'>('folder')
+  const [showRestoreModal, setShowRestoreModal] = useState(false)
+  const [versionToRestore, setVersionToRestore] = useState<FileVersion | null>(null)
+  const [showUpdateModal, setShowUpdateModal] = useState(false)
+  const [pendingFile, setPendingFile] = useState<{ file: File; parentId: string } | null>(null)
 
   const params = useParams()
   const navigate = useNavigate()
 
   const tokenProvider = useAccessToken()
   const { apps } = useManagerStatus()
+  const { profile } = useProfile()
 
   // compute per-user store base URL from the DOCKER_STORE app name when present
   const userStoreApp = apps.find((a) => a?.type === 'DOCKER_STORE')
   const storeBaseUrl = userStoreApp?.name ? `${apiConfig.storesScheme}://${userStoreApp.name}.${apiConfig.storesDomain}/` : undefined
+
+  // Create a stable fetchFn for the versioning module
+  const storeFetchFn: FetchFn = useCallback(
+    (path: string, init?: RequestInit) => fetchWithAuth(tokenProvider, path, init, storeBaseUrl),
+    [tokenProvider, storeBaseUrl]
+  )
+
+  useAutoVersioning(storeFetchFn)
 
   const storeApi = useStoreApi(tokenProvider, storeBaseUrl)
 
@@ -220,17 +246,111 @@ export function StorePage() {
   }
 
   const handleModalConfirm = async (data: string | File) => {
-    const parentId = params['*'] || (await storeApi.getRoot()).id
+    // Route is /s/:index/* so params['*'] is the folder/file ID (if any)
+    const raw = params['*']
+    const rootNode = await storeApi.getRoot()
+    const parentId = raw || rootNode.id
     try {
       if (modalType === 'folder') {
         await storeApi.create(parentId, data as string)
       } else {
-        await storeApi.create(parentId, (data as File).name, data as File)
+        const file = data as File
+        const locationHeader = await storeApi.create(parentId, file.name, file)
+        const nodeId = locationHeader?.split('/').pop() ?? parentId
+        emitFileSaved({
+          nodeId,
+          nodeName: file.name,
+          content: file,
+          author: profile?.email ?? profile?.username ?? 'unknown',
+        })
       }
       setReloadKey(k => k + 1)
       setShowCreateModal(false)
+    } catch (err: unknown) {
+      const errorMessage = err instanceof Error ? err.message : String(err)
+      if (errorMessage.includes('already-exists') || errorMessage.includes('already exists')) {
+        // File already exists on backend - offer to save a new version locally
+        const file = data as File
+        setPendingFile({ file, parentId })
+        setShowCreateModal(false)
+        setShowUpdateModal(true)
+      } else {
+        console.error('Create failed', err)
+      }
+    }
+  }
+
+  const handleConfirmUpdate = async () => {
+    if (!pendingFile) return
+
+    try {
+      // Find the existing node to link the version to the same nodeId
+      const existingNode = nodes.find(n => n.name === pendingFile.file.name)
+      const nodeId = existingNode?.id ?? pendingFile.parentId
+
+      // Save as a new version via the versioning API
+      emitFileSaved({
+        nodeId,
+        nodeName: pendingFile.file.name,
+        content: pendingFile.file,
+        author: profile?.email ?? profile?.username ?? 'unknown',
+      })
+    } finally {
+      setShowUpdateModal(false)
+      setPendingFile(null)
+    }
+  }
+
+  const handlePreviewVersion = async (version: FileVersion) => {
+    try {
+      const res = await storeFetchFn(`/api/versions/${encodeURIComponent(version.id)}/content`)
+      const blob = await res.blob()
+      const url = URL.createObjectURL(blob)
+      window.open(url, '_blank')
     } catch (err) {
-      console.error('Create failed', err)
+      console.error('Preview version failed', err)
+    }
+  }
+
+  const handleRestoreVersion = (version: FileVersion) => {
+    setVersionToRestore(version)
+    setShowRestoreModal(true)
+  }
+
+  const handleConfirmRestore = async () => {
+    if (!versionToRestore || !selected) return
+
+    try {
+      // Fetch the version content from backend versioning API
+      const contentRes = await storeFetchFn(`/api/versions/${encodeURIComponent(versionToRestore.id)}/content`)
+      const blob = await contentRes.blob()
+
+      // Create a new version from the restored content (tracability)
+      emitFileSaved({
+        nodeId: selected.id,
+        nodeName: selected.name,
+        content: blob,
+        author: profile?.email ?? profile?.username ?? 'unknown',
+      })
+
+      emitVersionRestored({
+        versionId: versionToRestore.id,
+        nodeId: selected.id,
+        nodeName: selected.name,
+      })
+
+      globalThis.dispatchEvent(
+        new CustomEvent('mbyte-toast', {
+          detail: { message: 'Fichier restauré avec succès. Une nouvelle version a été créée.' },
+        })
+      )
+
+      setReloadKey(k => k + 1)
+    } catch (err) {
+      console.error('Restore failed', err)
+    } finally {
+      setShowRestoreModal(false)
+      setVersionToRestore(null)
     }
   }
 
@@ -253,6 +373,8 @@ export function StorePage() {
         setViewMode={setViewMode}
         detailVisible={detailVisible}
         toggleDetail={() => setDetailVisible((v) => !v)}
+        historyVisible={historyVisible}
+        toggleHistory={() => setHistoryVisible((v) => !v)}
         setCurrentPath={setCurrentPath}
         onNavigate={(folderId) => handleOpenFolder(folderId)}
         onCreateFolder={handleCreateFolder}
@@ -271,6 +393,14 @@ export function StorePage() {
         </div>
 
         {detailVisible && <InfoPanel selected={selected ?? null} />}
+        {historyVisible && (
+          <VersionHistoryPanel
+            selected={selected ?? null}
+            fetchFn={storeFetchFn}
+            onPreview={handlePreviewVersion}
+            onRestore={handleRestoreVersion}
+          />
+        )}
       </div>
 
       {showCreateModal && (
@@ -281,6 +411,26 @@ export function StorePage() {
           onClose={() => setShowCreateModal(false)}
         />
       )}
+
+      <RestoreConfirmModal
+        visible={showRestoreModal}
+        version={versionToRestore}
+        onConfirm={handleConfirmRestore}
+        onClose={() => {
+          setShowRestoreModal(false)
+          setVersionToRestore(null)
+        }}
+      />
+
+      <ConfirmUpdateModal
+        visible={showUpdateModal}
+        fileName={pendingFile?.file.name ?? ''}
+        onConfirm={handleConfirmUpdate}
+        onCancel={() => {
+          setShowUpdateModal(false)
+          setPendingFile(null)
+        }}
+      />
     </CContainer>
   )
 }

--- a/gui/src/javascript/versioning/components/RestoreConfirmModal.tsx
+++ b/gui/src/javascript/versioning/components/RestoreConfirmModal.tsx
@@ -1,0 +1,59 @@
+import {
+  CModal,
+  CModalHeader,
+  CModalTitle,
+  CModalBody,
+  CModalFooter,
+  CButton,
+} from '@coreui/react'
+import { CIcon } from '@coreui/icons-react'
+import { cilWarning } from '@coreui/icons'
+import FileVersion from '../entities/FileVersion'
+
+type RestoreConfirmModalProps = Readonly<{
+  visible: boolean
+  version: FileVersion | null
+  onConfirm: () => void
+  onClose: () => void
+}>
+
+export function RestoreConfirmModal({
+  visible,
+  version,
+  onConfirm,
+  onClose,
+}: RestoreConfirmModalProps) {
+  if (!version) return null
+
+  return (
+    <CModal visible={visible} onClose={onClose} alignment="center">
+      <CModalHeader>
+        <CModalTitle>Restaurer une version</CModalTitle>
+      </CModalHeader>
+      <CModalBody>
+        <div className="d-flex align-items-start gap-3">
+          <CIcon icon={cilWarning} size="xl" className="text-warning" />
+          <div>
+            <p className="mb-2">Êtes-vous sûr de vouloir restaurer cette version ?</p>
+            <div className="text-muted small">
+              <div><strong>Fichier :</strong> {version.nodeName}</div>
+              <div><strong>Date :</strong> {version.formattedDate}</div>
+              <div><strong>Auteur :</strong> {version.author}</div>
+            </div>
+            <p className="mt-3 mb-0 text-muted small">
+              Le fichier actuel sera remplacé par cette version. Une nouvelle version sera créée pour tracer cette action.
+            </p>
+          </div>
+        </div>
+      </CModalBody>
+      <CModalFooter>
+        <CButton color="secondary" onClick={onClose}>
+          Annuler
+        </CButton>
+        <CButton color="primary" onClick={onConfirm}>
+          Restaurer
+        </CButton>
+      </CModalFooter>
+    </CModal>
+  )
+}

--- a/gui/src/javascript/versioning/components/VersionHistoryPanel.tsx
+++ b/gui/src/javascript/versioning/components/VersionHistoryPanel.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useState, useCallback } from 'react'
+import {
+  CCard,
+  CCardBody,
+  CListGroup,
+  CListGroupItem,
+  CButton,
+  CSpinner,
+  CFormSelect,
+} from '@coreui/react'
+import { CIcon } from '@coreui/icons-react'
+import { cilHistory, cilCloudDownload, cilReload } from '@coreui/icons'
+import Node from '../../api/entities/Node'
+import FileVersion from '../entities/FileVersion'
+import { useVersioningService } from '../useVersioningService'
+import { onVersionCreated } from '../versioningEvents'
+import type { FetchFn } from '../versioningService'
+
+type SortBy = 'date-desc' | 'date-asc' | 'author'
+
+type VersionHistoryPanelProps = Readonly<{
+  selected: Node | null
+  fetchFn: FetchFn
+  onPreview: (version: FileVersion) => void
+  onRestore: (version: FileVersion) => void
+}>
+
+export function VersionHistoryPanel({ selected, fetchFn, onPreview, onRestore }: VersionHistoryPanelProps) {
+  const versioningService = useVersioningService(fetchFn)
+
+  const [versions, setVersions] = useState<FileVersion[]>([])
+  const [loading, setLoading] = useState(false)
+  const [sortBy, setSortBy] = useState<SortBy>('date-desc')
+
+  const loadVersions = useCallback(async () => {
+    if (!selected || !selected.isFile) {
+      setVersions([])
+      return
+    }
+
+    setLoading(true)
+    try {
+      const history = await versioningService.getVersionHistory(selected.id)
+      setVersions(history)
+    } catch (err) {
+      console.error('Failed to load version history', err)
+      setVersions([])
+    } finally {
+      setLoading(false)
+    }
+  }, [selected, versioningService])
+
+  useEffect(() => {
+    loadVersions()
+  }, [loadVersions])
+
+  useEffect(() => {
+    const unsubscribe = onVersionCreated((detail) => {
+      if (selected && detail.nodeId === selected.id) {
+        loadVersions()
+      }
+    })
+    return unsubscribe
+  }, [selected, loadVersions])
+
+  const sortedVersions = [...versions].sort((a, b) => {
+    switch (sortBy) {
+      case 'date-asc':
+        return a.timestamp - b.timestamp
+      case 'author':
+        return a.author.localeCompare(b.author)
+      case 'date-desc':
+      default:
+        return b.timestamp - a.timestamp
+    }
+  })
+
+  const formatDate = (ts: number) => {
+    const date = new Date(ts)
+    return date.toLocaleDateString() + ' ' + date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  }
+
+  return (
+    <div style={{ width: 360, borderLeft: '1px solid rgba(0,0,0,0.08)', overflow: 'auto' }}>
+      <div className="p-3">
+        <div className="d-flex align-items-center gap-2 mb-3">
+          <CIcon icon={cilHistory} />
+          <h6 className="mb-0">Historique des versions</h6>
+        </div>
+
+        {!selected && (
+          <div className="text-muted small">Sélectionnez un fichier pour voir son historique</div>
+        )}
+
+        {selected && !selected.isFile && (
+          <div className="text-muted small">L'historique est disponible uniquement pour les fichiers</div>
+        )}
+
+        {selected && selected.isFile && (
+          <>
+            <div className="mb-3">
+              <CFormSelect
+                size="sm"
+                value={sortBy}
+                onChange={(e) => setSortBy(e.target.value as SortBy)}
+              >
+                <option value="date-desc">Date (plus récent)</option>
+                <option value="date-asc">Date (plus ancien)</option>
+                <option value="author">Auteur</option>
+              </CFormSelect>
+            </div>
+
+            {loading && (
+              <div className="text-center py-3">
+                <CSpinner size="sm" />
+              </div>
+            )}
+
+            {!loading && versions.length === 0 && (
+              <div className="text-muted small">Aucune version enregistrée</div>
+            )}
+
+            {!loading && versions.length > 0 && (
+              <CCard>
+                <CCardBody className="p-0">
+                  <CListGroup flush>
+                    {sortedVersions.map((version, index) => (
+                      <CListGroupItem key={version.id} className="px-3 py-2">
+                        <div className="d-flex justify-content-between align-items-start">
+                          <div className="flex-grow-1">
+                            <div className="fw-semibold small">
+                              #{versions.length - index}
+                            </div>
+                            <div className="text-muted small">
+                              {formatDate(version.timestamp)}
+                            </div>
+                            <div className="text-muted small">
+                              {version.author}
+                            </div>
+                            {version.comment && (
+                              <div className="text-muted small fst-italic">
+                                {version.comment}
+                              </div>
+                            )}
+                          </div>
+                          <div className="d-flex gap-1">
+                            <CButton
+                              color="light"
+                              size="sm"
+                              title="Prévisualiser"
+                              onClick={() => onPreview(version)}
+                            >
+                              <CIcon icon={cilCloudDownload} size="sm" />
+                            </CButton>
+                            <CButton
+                              color="primary"
+                              size="sm"
+                              title="Restaurer"
+                              onClick={() => onRestore(version)}
+                            >
+                              <CIcon icon={cilReload} size="sm" />
+                            </CButton>
+                          </div>
+                        </div>
+                      </CListGroupItem>
+                    ))}
+                  </CListGroup>
+                </CCardBody>
+              </CCard>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/gui/src/javascript/versioning/components/index.ts
+++ b/gui/src/javascript/versioning/components/index.ts
@@ -1,0 +1,2 @@
+export { VersionHistoryPanel } from './VersionHistoryPanel'
+export { RestoreConfirmModal } from './RestoreConfirmModal'

--- a/gui/src/javascript/versioning/entities/FileVersion.ts
+++ b/gui/src/javascript/versioning/entities/FileVersion.ts
@@ -1,0 +1,69 @@
+export type FileVersionData = {
+  id: string
+  nodeId: string
+  nodeName: string
+  author: string
+  timestamp: number
+  versionNumber?: number
+  mimetype?: string
+  size?: number
+  comment?: string
+}
+
+export default class FileVersion {
+  readonly data: FileVersionData
+
+  constructor(data: FileVersionData) {
+    this.data = data
+  }
+
+  static fromData(data: FileVersionData): FileVersion {
+    return new FileVersion(data)
+  }
+
+  static fromDto(dto: any): FileVersion {
+    return new FileVersion({
+      id: dto.id,
+      nodeId: dto.nodeId,
+      nodeName: dto.nodeName,
+      author: dto.author ?? 'unknown',
+      timestamp: dto.createdAt ? new Date(dto.createdAt).getTime() : Date.now(),
+      versionNumber: dto.versionNumber,
+      mimetype: dto.mimetype,
+      size: dto.size,
+      comment: dto.comment,
+    })
+  }
+
+  get id(): string {
+    return this.data.id
+  }
+
+  get nodeId(): string {
+    return this.data.nodeId
+  }
+
+  get nodeName(): string {
+    return this.data.nodeName
+  }
+
+  get author(): string {
+    return this.data.author
+  }
+
+  get timestamp(): number {
+    return this.data.timestamp
+  }
+
+  get versionNumber(): number | undefined {
+    return this.data.versionNumber
+  }
+
+  get comment(): string | undefined {
+    return this.data.comment
+  }
+
+  get formattedDate(): string {
+    return new Date(this.timestamp).toLocaleString()
+  }
+}

--- a/gui/src/javascript/versioning/index.ts
+++ b/gui/src/javascript/versioning/index.ts
@@ -1,0 +1,18 @@
+
+export { default as FileVersion, type FileVersionData } from './entities/FileVersion'
+export { createVersioningService, type VersioningService, type FetchFn } from './versioningService'
+export { useVersioningService } from './useVersioningService'
+export { useAutoVersioning } from './useAutoVersioning'
+export {
+  VERSIONING_EVENTS,
+  emitFileSaved,
+  emitVersionCreated,
+  emitVersionRestored,
+  onFileSaved,
+  onVersionCreated,
+  onVersionRestored,
+  type FileSavedEventDetail,
+  type VersionCreatedEventDetail,
+  type VersionRestoredEventDetail,
+} from './versioningEvents'
+export { VersionHistoryPanel, RestoreConfirmModal } from './components'

--- a/gui/src/javascript/versioning/useAutoVersioning.ts
+++ b/gui/src/javascript/versioning/useAutoVersioning.ts
@@ -1,0 +1,46 @@
+
+import { useEffect } from 'react'
+import { useVersioningService } from './useVersioningService'
+import {
+  onFileSaved,
+  emitVersionCreated,
+  type FileSavedEventDetail,
+} from './versioningEvents'
+import type { FetchFn } from './versioningService'
+
+export function useAutoVersioning(fetchFn: FetchFn) {
+  const versioningService = useVersioningService(fetchFn)
+
+  useEffect(() => {
+    const handleFileSaved = async (detail: FileSavedEventDetail) => {
+      try {
+        const version = await versioningService.createVersion(
+          detail.nodeId,
+          detail.nodeName,
+          detail.content,
+          detail.author
+        )
+
+        const count = await versioningService.getVersionCount(detail.nodeId)
+
+        emitVersionCreated({
+          versionId: version.id,
+          nodeId: detail.nodeId,
+          nodeName: detail.nodeName,
+          versionNumber: count,
+        })
+
+        globalThis.dispatchEvent(
+          new CustomEvent('mbyte-toast', {
+            detail: { message: `Version #${count} enregistrée` },
+          })
+        )
+      } catch (err) {
+        console.error('[versioning] Failed to create version', err)
+      }
+    }
+
+    const unsubscribe = onFileSaved(handleFileSaved)
+    return () => { unsubscribe() }
+  }, [versioningService])
+}

--- a/gui/src/javascript/versioning/useVersioningService.ts
+++ b/gui/src/javascript/versioning/useVersioningService.ts
@@ -1,0 +1,36 @@
+
+import { useMemo } from 'react'
+import { createVersioningService, type VersioningService, type FetchFn } from './versioningService'
+
+function dispatchToast(message: string) {
+  globalThis.dispatchEvent(new CustomEvent('mbyte-toast', { detail: { message } }))
+}
+
+export function useVersioningService(fetchFn: FetchFn) {
+  const service = useMemo(() => createVersioningService(fetchFn), [fetchFn])
+
+  const wrap = <T extends (...args: any[]) => Promise<any>>(fn: T) => {
+    return (async (...args: Parameters<T>): Promise<ReturnType<T>> => {
+      try {
+        return await fn(...args)
+      } catch (err: any) {
+        const msg = err?.message ?? String(err)
+        dispatchToast(msg)
+        throw err
+      }
+    }) as T
+  }
+
+  return useMemo(() => {
+    const out: any = {}
+    Object.keys(service).forEach((k) => {
+      const v: any = (service as any)[k]
+      if (typeof v === 'function') {
+        out[k] = wrap(v.bind(service))
+      } else {
+        out[k] = v
+      }
+    })
+    return out as VersioningService
+  }, [service])
+}

--- a/gui/src/javascript/versioning/versioningEvents.ts
+++ b/gui/src/javascript/versioning/versioningEvents.ts
@@ -1,0 +1,65 @@
+
+export type FileSavedEventDetail = {
+  nodeId: string
+  nodeName: string
+  content: Blob
+  author: string
+}
+
+export type VersionCreatedEventDetail = {
+  versionId: string
+  nodeId: string
+  nodeName: string
+  versionNumber: number
+}
+
+export type VersionRestoredEventDetail = {
+  versionId: string
+  nodeId: string
+  nodeName: string
+}
+
+export const VERSIONING_EVENTS = {
+  FILE_SAVED: 'mbyte-file-saved',
+  VERSION_CREATED: 'mbyte-version-created',
+  VERSION_RESTORED: 'mbyte-version-restored',
+} as const
+
+export function emitFileSaved(detail: FileSavedEventDetail) {
+  globalThis.dispatchEvent(new CustomEvent(VERSIONING_EVENTS.FILE_SAVED, { detail }))
+}
+
+export function emitVersionCreated(detail: VersionCreatedEventDetail) {
+  globalThis.dispatchEvent(new CustomEvent(VERSIONING_EVENTS.VERSION_CREATED, { detail }))
+}
+
+export function emitVersionRestored(detail: VersionRestoredEventDetail) {
+  globalThis.dispatchEvent(new CustomEvent(VERSIONING_EVENTS.VERSION_RESTORED, { detail }))
+}
+
+export function onFileSaved(handler: (detail: FileSavedEventDetail) => void): () => void {
+  const listener = (event: Event) => {
+    const ce = event as CustomEvent<FileSavedEventDetail>
+    handler(ce.detail)
+  }
+  globalThis.addEventListener(VERSIONING_EVENTS.FILE_SAVED, listener)
+  return () => globalThis.removeEventListener(VERSIONING_EVENTS.FILE_SAVED, listener)
+}
+
+export function onVersionCreated(handler: (detail: VersionCreatedEventDetail) => void): () => void {
+  const listener = (event: Event) => {
+    const ce = event as CustomEvent<VersionCreatedEventDetail>
+    handler(ce.detail)
+  }
+  globalThis.addEventListener(VERSIONING_EVENTS.VERSION_CREATED, listener)
+  return () => globalThis.removeEventListener(VERSIONING_EVENTS.VERSION_CREATED, listener)
+}
+
+export function onVersionRestored(handler: (detail: VersionRestoredEventDetail) => void): () => void {
+  const listener = (event: Event) => {
+    const ce = event as CustomEvent<VersionRestoredEventDetail>
+    handler(ce.detail)
+  }
+  globalThis.addEventListener(VERSIONING_EVENTS.VERSION_RESTORED, listener)
+  return () => globalThis.removeEventListener(VERSIONING_EVENTS.VERSION_RESTORED, listener)
+}

--- a/gui/src/javascript/versioning/versioningService.ts
+++ b/gui/src/javascript/versioning/versioningService.ts
@@ -1,0 +1,86 @@
+
+import FileVersion from './entities/FileVersion'
+
+export type FetchFn = (path: string, init?: RequestInit) => Promise<Response>
+
+export function createVersioningService(fetchFn: FetchFn) {
+  return {
+    async createVersion(
+      nodeId: string,
+      nodeName: string,
+      content: Blob,
+      _author?: string,
+      comment?: string
+    ): Promise<FileVersion> {
+      const fd = new FormData()
+      fd.append('name', nodeName)
+      fd.append('file', content)
+      fd.append('mimetype', content.type || 'application/octet-stream')
+      fd.append('size', String(content.size))
+      if (comment) fd.append('comment', comment)
+
+      const res = await fetchFn(`/api/versions/node/${encodeURIComponent(nodeId)}`, {
+        method: 'POST',
+        body: fd,
+      })
+      if (!res.ok) {
+        const text = await res.text()
+        throw new Error(`Create version failed (${res.status}): ${text}`)
+      }
+      const dto = await res.json()
+      return FileVersion.fromDto(dto)
+    },
+
+    async getVersionHistory(nodeId: string): Promise<FileVersion[]> {
+      const res = await fetchFn(`/api/versions/node/${encodeURIComponent(nodeId)}`, {
+        method: 'GET',
+      })
+      if (!res.ok) {
+        const text = await res.text()
+        throw new Error(`Get history failed (${res.status}): ${text}`)
+      }
+      const arr = await res.json()
+      return (arr as any[]).map((dto) => FileVersion.fromDto(dto))
+    },
+
+    async getVersion(versionId: string): Promise<FileVersion | null> {
+      const res = await fetchFn(`/api/versions/${encodeURIComponent(versionId)}`, {
+        method: 'GET',
+      })
+      if (res.status === 404) return null
+      if (!res.ok) {
+        const text = await res.text()
+        throw new Error(`Get version failed (${res.status}): ${text}`)
+      }
+      const dto = await res.json()
+      return FileVersion.fromDto(dto)
+    },
+
+    async deleteVersion(versionId: string): Promise<void> {
+      const res = await fetchFn(`/api/versions/${encodeURIComponent(versionId)}`, {
+        method: 'DELETE',
+      })
+      if (!res.ok) {
+        const text = await res.text()
+        throw new Error(`Delete version failed (${res.status}): ${text}`)
+      }
+    },
+
+    async getVersionCount(nodeId: string): Promise<number> {
+      const res = await fetchFn(`/api/versions/node/${encodeURIComponent(nodeId)}`, {
+        method: 'GET',
+      })
+      if (!res.ok) return 0
+      const arr = await res.json()
+      return (arr as any[]).length
+    },
+
+    async getVersionContent(versionId: string): Promise<Response> {
+      return fetchFn(`/api/versions/${encodeURIComponent(versionId)}/content`, {
+        method: 'GET',
+      })
+    },
+  }
+}
+
+export type VersioningService = ReturnType<typeof createVersioningService>

--- a/gui/vite.config.ts
+++ b/gui/vite.config.ts
@@ -24,4 +24,7 @@ export default defineConfig({
     outDir: 'target/gui-dist',
     emptyOutDir: true,
   },
+  resolve: {
+    dedupe: ['react', 'react-dom'],
+  },
 })

--- a/store/src/main/java/fr/jayblanc/mbyte/store/api/dto/FileVersionDto.java
+++ b/store/src/main/java/fr/jayblanc/mbyte/store/api/dto/FileVersionDto.java
@@ -1,0 +1,51 @@
+package fr.jayblanc.mbyte.store.api.dto;
+
+import fr.jayblanc.mbyte.store.versioning.entity.FileVersion;
+
+import java.util.Date;
+
+public class FileVersionDto {
+
+    private String id;
+    private String nodeId;
+    private String nodeName;
+    private String author;
+    private String comment;
+    private String mimetype;
+    private long size;
+    private long versionNumber;
+    private Date createdAt;
+
+    public static FileVersionDto fromEntity(FileVersion v) {
+        FileVersionDto dto = new FileVersionDto();
+        dto.id = v.getId();
+        dto.nodeId = v.getNodeId();
+        dto.nodeName = v.getNodeName();
+        dto.author = v.getAuthor();
+        dto.comment = v.getComment();
+        dto.mimetype = v.getMimetype();
+        dto.size = v.getSize();
+        dto.versionNumber = v.getVersionNumber();
+        dto.createdAt = new Date(v.getCreatedAt());
+        return dto;
+    }
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+    public String getNodeId() { return nodeId; }
+    public void setNodeId(String nodeId) { this.nodeId = nodeId; }
+    public String getNodeName() { return nodeName; }
+    public void setNodeName(String nodeName) { this.nodeName = nodeName; }
+    public String getAuthor() { return author; }
+    public void setAuthor(String author) { this.author = author; }
+    public String getComment() { return comment; }
+    public void setComment(String comment) { this.comment = comment; }
+    public String getMimetype() { return mimetype; }
+    public void setMimetype(String mimetype) { this.mimetype = mimetype; }
+    public long getSize() { return size; }
+    public void setSize(long size) { this.size = size; }
+    public long getVersionNumber() { return versionNumber; }
+    public void setVersionNumber(long versionNumber) { this.versionNumber = versionNumber; }
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
+}

--- a/store/src/main/java/fr/jayblanc/mbyte/store/api/dto/VersionCreateDto.java
+++ b/store/src/main/java/fr/jayblanc/mbyte/store/api/dto/VersionCreateDto.java
@@ -1,0 +1,43 @@
+package fr.jayblanc.mbyte.store.api.dto;
+
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.core.MediaType;
+import org.jboss.resteasy.annotations.providers.multipart.PartType;
+
+import java.io.InputStream;
+
+public class VersionCreateDto {
+
+    @FormParam("name")
+    @PartType(MediaType.TEXT_PLAIN)
+    private String name;
+
+    @FormParam("file")
+    @PartType(MediaType.APPLICATION_OCTET_STREAM)
+    private InputStream file;
+
+    @FormParam("mimetype")
+    @PartType(MediaType.TEXT_PLAIN)
+    private String mimetype;
+
+    @FormParam("size")
+    @PartType(MediaType.TEXT_PLAIN)
+    private String size;
+
+    @FormParam("comment")
+    @PartType(MediaType.TEXT_PLAIN)
+    private String comment;
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public InputStream getFile() { return file; }
+    public void setFile(InputStream file) { this.file = file; }
+    public String getMimetype() { return mimetype; }
+    public void setMimetype(String mimetype) { this.mimetype = mimetype; }
+    public long getSize() {
+        try { return Long.parseLong(size); } catch (Exception e) { return 0; }
+    }
+    public void setSize(String size) { this.size = size; }
+    public String getComment() { return comment; }
+    public void setComment(String comment) { this.comment = comment; }
+}

--- a/store/src/main/java/fr/jayblanc/mbyte/store/api/resources/NodesResource.java
+++ b/store/src/main/java/fr/jayblanc/mbyte/store/api/resources/NodesResource.java
@@ -148,6 +148,7 @@ public class NodesResource {
             NodeNotEmptyException, NodeNotFoundException, NodeTypeException, NodeAlreadyExistsException, DataStoreException, DataNotFoundException, NodePersistenceException, NotificationServiceException {
         LOGGER.log(Level.INFO, "PUT /api/nodes/{0}/{1}", new Object[]{id, name});
         service.remove(id, name);
+        service.flush();
         service.add(id, name, data);
         return Response.noContent().build();
     }

--- a/store/src/main/java/fr/jayblanc/mbyte/store/api/resources/VersionsResource.java
+++ b/store/src/main/java/fr/jayblanc/mbyte/store/api/resources/VersionsResource.java
@@ -1,0 +1,99 @@
+package fr.jayblanc.mbyte.store.api.resources;
+
+import fr.jayblanc.mbyte.store.api.dto.FileVersionDto;
+import fr.jayblanc.mbyte.store.api.dto.VersionCreateDto;
+import fr.jayblanc.mbyte.store.api.filter.OnlyOwner;
+import fr.jayblanc.mbyte.store.auth.AuthenticationService;
+import fr.jayblanc.mbyte.store.versioning.VersioningService;
+import fr.jayblanc.mbyte.store.versioning.entity.FileVersion;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Path("versions")
+@OnlyOwner
+public class VersionsResource {
+
+    private static final Logger LOGGER = Logger.getLogger(VersionsResource.class.getName());
+
+    @Inject VersioningService versioningService;
+    @Inject AuthenticationService auth;
+
+    @GET
+    @Path("node/{nodeId}")
+    @Transactional(Transactional.TxType.REQUIRED)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getHistory(@PathParam("nodeId") String nodeId) {
+        LOGGER.log(Level.INFO, "GET /api/versions/node/{0}", nodeId);
+        List<FileVersion> versions = versioningService.getHistory(nodeId);
+        List<FileVersionDto> dtos = versions.stream().map(FileVersionDto::fromEntity).toList();
+        return Response.ok(dtos).build();
+    }
+
+    @POST
+    @Path("node/{nodeId}")
+    @Transactional(Transactional.TxType.REQUIRED)
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response createVersion(
+            @PathParam("nodeId") String nodeId,
+            @MultipartForm VersionCreateDto dto) {
+        LOGGER.log(Level.INFO, "POST /api/versions/node/{0}", nodeId);
+        String author = auth.getConnectedProfile().getUsername();
+        FileVersion version = versioningService.createVersion(
+                nodeId, dto.getName(), dto.getFile(), dto.getMimetype(), dto.getSize(), author, dto.getComment());
+        return Response.ok(FileVersionDto.fromEntity(version)).build();
+    }
+
+    @GET
+    @Path("{versionId}")
+    @Transactional(Transactional.TxType.REQUIRED)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getVersion(@PathParam("versionId") String versionId) {
+        LOGGER.log(Level.INFO, "GET /api/versions/{0}", versionId);
+        FileVersion version = versioningService.getVersion(versionId);
+        if (version == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        return Response.ok(FileVersionDto.fromEntity(version)).build();
+    }
+
+    @GET
+    @Path("{versionId}/content")
+    @Transactional(Transactional.TxType.REQUIRED)
+    @Produces(MediaType.WILDCARD)
+    public Response getVersionContent(@PathParam("versionId") String versionId) {
+        LOGGER.log(Level.INFO, "GET /api/versions/{0}/content", versionId);
+        FileVersion version = versioningService.getVersion(versionId);
+        if (version == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        InputStream content = versioningService.getVersionContent(versionId);
+        if (content == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        return Response.ok(content)
+                .header("Content-Type", version.getMimetype())
+                .header("Content-Length", version.getSize())
+                .header("Content-Disposition", "filename=" + version.getNodeName())
+                .build();
+    }
+
+    @DELETE
+    @Path("{versionId}")
+    @Transactional(Transactional.TxType.REQUIRED)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response deleteVersion(@PathParam("versionId") String versionId) {
+        LOGGER.log(Level.INFO, "DELETE /api/versions/{0}", versionId);
+        versioningService.deleteVersion(versionId);
+        return Response.noContent().build();
+    }
+}

--- a/store/src/main/java/fr/jayblanc/mbyte/store/data/DataStoreBean.java
+++ b/store/src/main/java/fr/jayblanc/mbyte/store/data/DataStoreBean.java
@@ -155,7 +155,12 @@ public class DataStoreBean implements DataStore {
 
     @Override
     public void delete(String key) throws DataStoreException {
-        throw new DataStoreException("NOT IMPLEMENTED");
+        Path file = Paths.get(base.toString(), key);
+        try {
+            Files.deleteIfExists(file);
+        } catch (IOException e) {
+            throw new DataStoreException("unable to delete file from storage", e);
+        }
     }
 
 

--- a/store/src/main/java/fr/jayblanc/mbyte/store/files/FileService.java
+++ b/store/src/main/java/fr/jayblanc/mbyte/store/files/FileService.java
@@ -45,6 +45,8 @@ public interface FileService {
 
     void remove(String parent, String name) throws NodeNotFoundException, NodeNotEmptyException, NodeTypeException, DataStoreException, NodePersistenceException, NotificationServiceException;
 
+    void flush();
+
     String getFullPath(List<Node> nodesPath);
 
     List<Node> findAll() throws NodeNotFoundException;

--- a/store/src/main/java/fr/jayblanc/mbyte/store/files/FileServiceBean.java
+++ b/store/src/main/java/fr/jayblanc/mbyte/store/files/FileServiceBean.java
@@ -203,7 +203,7 @@ public class FileServiceBean implements FileService, IndexableContentProvider {
         if (node == null) {
             throw new NodeNotFoundException("A node with name: " + name + " does not exists in tree with id: " + pnode.getId());
         }
-        int children = em.createNamedQuery("Node.countChildren", Integer.class).setParameter("parent", pnode.getId()).getSingleResult();
+        long children = em.createNamedQuery("Node.countChildren", Long.class).setParameter("parent", node.getId()).getSingleResult();
         if (children > 0) {
             throw new NodeNotEmptyException("The node with name: " + name + " is not empty");
         }
@@ -217,6 +217,11 @@ public class FileServiceBean implements FileService, IndexableContentProvider {
         pnode.setModification(System.currentTimeMillis());
         notification.notify(eventType, node.getId());
         notification.notify("folder.update", pnode.getId());
+    }
+
+    @Override
+    public void flush() {
+        em.flush();
     }
 
     //INTERNAL OPERATIONS

--- a/store/src/main/java/fr/jayblanc/mbyte/store/versioning/VersioningService.java
+++ b/store/src/main/java/fr/jayblanc/mbyte/store/versioning/VersioningService.java
@@ -1,0 +1,22 @@
+package fr.jayblanc.mbyte.store.versioning;
+
+import fr.jayblanc.mbyte.store.versioning.entity.FileVersion;
+
+import java.io.InputStream;
+import java.util.List;
+
+public interface VersioningService {
+
+    FileVersion createVersion(String nodeId, String nodeName, InputStream content,
+                              String mimetype, long size, String author, String comment);
+
+    List<FileVersion> getHistory(String nodeId);
+
+    FileVersion getVersion(String versionId);
+
+    InputStream getVersionContent(String versionId);
+
+    void deleteVersion(String versionId);
+
+    long getVersionCount(String nodeId);
+}

--- a/store/src/main/java/fr/jayblanc/mbyte/store/versioning/VersioningServiceBean.java
+++ b/store/src/main/java/fr/jayblanc/mbyte/store/versioning/VersioningServiceBean.java
@@ -1,0 +1,111 @@
+package fr.jayblanc.mbyte.store.versioning;
+
+import fr.jayblanc.mbyte.store.data.DataStore;
+import fr.jayblanc.mbyte.store.data.exception.DataNotFoundException;
+import fr.jayblanc.mbyte.store.data.exception.DataStoreException;
+import fr.jayblanc.mbyte.store.versioning.entity.FileVersion;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@ApplicationScoped
+public class VersioningServiceBean implements VersioningService {
+
+    private static final Logger LOGGER = Logger.getLogger(VersioningServiceBean.class.getName());
+
+    @Inject EntityManager em;
+    @Inject DataStore datastore;
+
+    @Override
+    @Transactional(Transactional.TxType.REQUIRED)
+    public FileVersion createVersion(String nodeId, String nodeName, InputStream content,
+                                     String mimetype, long size, String author, String comment) {
+        LOGGER.log(Level.INFO, "Creating version for node: {0} ({1})", new Object[]{nodeId, nodeName});
+
+        long count = getVersionCount(nodeId);
+
+        String contentHash = null;
+        long contentSize = size;
+        if (content != null) {
+            try {
+                contentHash = datastore.put(content);
+                contentSize = datastore.size(contentHash);
+            } catch (DataStoreException | DataNotFoundException e) {
+                LOGGER.log(Level.WARNING, "Failed to store version content", e);
+                throw new RuntimeException("Failed to store version content", e);
+            }
+        }
+
+        FileVersion version = new FileVersion();
+        version.setId(UUID.randomUUID().toString());
+        version.setNodeId(nodeId);
+        version.setNodeName(nodeName);
+        version.setContent(contentHash);
+        version.setMimetype(mimetype);
+        version.setSize(contentSize);
+        version.setAuthor(author);
+        version.setComment(comment);
+        version.setCreatedAt(System.currentTimeMillis());
+        version.setVersionNumber(count + 1);
+
+        em.persist(version);
+        LOGGER.log(Level.INFO, "Version #{0} created for node {1}", new Object[]{version.getVersionNumber(), nodeId});
+        return version;
+    }
+
+    @Override
+    public List<FileVersion> getHistory(String nodeId) {
+        return em.createNamedQuery("FileVersion.findByNodeId", FileVersion.class)
+                .setParameter("nodeId", nodeId)
+                .getResultList();
+    }
+
+    @Override
+    public FileVersion getVersion(String versionId) {
+        return em.find(FileVersion.class, versionId);
+    }
+
+    @Override
+    public InputStream getVersionContent(String versionId) {
+        FileVersion version = getVersion(versionId);
+        if (version == null || version.getContent() == null) {
+            return null;
+        }
+        try {
+            return datastore.get(version.getContent());
+        } catch (DataStoreException | DataNotFoundException e) {
+            LOGGER.log(Level.WARNING, "Failed to get version content", e);
+            return null;
+        }
+    }
+
+    @Override
+    @Transactional(Transactional.TxType.REQUIRED)
+    public void deleteVersion(String versionId) {
+        FileVersion version = getVersion(versionId);
+        if (version != null) {
+            if (version.getContent() != null) {
+                try {
+                    datastore.delete(version.getContent());
+                } catch (DataStoreException e) {
+                    LOGGER.log(Level.WARNING, "Failed to delete version content from datastore", e);
+                }
+            }
+            em.remove(version);
+        }
+    }
+
+    @Override
+    public long getVersionCount(String nodeId) {
+        return em.createNamedQuery("FileVersion.countByNodeId", Long.class)
+                .setParameter("nodeId", nodeId)
+                .getSingleResult();
+    }
+}

--- a/store/src/main/java/fr/jayblanc/mbyte/store/versioning/entity/FileVersion.java
+++ b/store/src/main/java/fr/jayblanc/mbyte/store/versioning/entity/FileVersion.java
@@ -1,0 +1,79 @@
+package fr.jayblanc.mbyte.store.versioning.entity;
+
+import jakarta.persistence.*;
+
+import java.io.Serializable;
+
+@Entity
+@Table(name = "file_version")
+@NamedQueries({
+        @NamedQuery(name = "FileVersion.findByNodeId",
+                query = "SELECT v FROM FileVersion v WHERE v.nodeId = :nodeId ORDER BY v.createdAt DESC"),
+        @NamedQuery(name = "FileVersion.countByNodeId",
+                query = "SELECT COUNT(v) FROM FileVersion v WHERE v.nodeId = :nodeId"),
+})
+public class FileVersion implements Serializable {
+
+    @Id
+    @Column(length = 50)
+    private String id;
+
+    @Column(name = "node_id", length = 50, nullable = false)
+    private String nodeId;
+
+    @Column(name = "node_name", length = 255)
+    private String nodeName;
+
+    @Column(length = 255)
+    private String content;
+
+    @Column(length = 50)
+    private String mimetype;
+
+    private long size;
+
+    @Column(length = 250)
+    private String author;
+
+    @Column(columnDefinition = "text")
+    private String comment;
+
+    @Column(name = "created_at", nullable = false)
+    private long createdAt;
+
+    @Column(name = "version_number", nullable = false)
+    private long versionNumber;
+
+    public FileVersion() {
+    }
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getNodeId() { return nodeId; }
+    public void setNodeId(String nodeId) { this.nodeId = nodeId; }
+
+    public String getNodeName() { return nodeName; }
+    public void setNodeName(String nodeName) { this.nodeName = nodeName; }
+
+    public String getContent() { return content; }
+    public void setContent(String content) { this.content = content; }
+
+    public String getMimetype() { return mimetype; }
+    public void setMimetype(String mimetype) { this.mimetype = mimetype; }
+
+    public long getSize() { return size; }
+    public void setSize(long size) { this.size = size; }
+
+    public String getAuthor() { return author; }
+    public void setAuthor(String author) { this.author = author; }
+
+    public String getComment() { return comment; }
+    public void setComment(String comment) { this.comment = comment; }
+
+    public long getCreatedAt() { return createdAt; }
+    public void setCreatedAt(long createdAt) { this.createdAt = createdAt; }
+
+    public long getVersionNumber() { return versionNumber; }
+    public void setVersionNumber(long versionNumber) { this.versionNumber = versionNumber; }
+}

--- a/store/src/main/resources/db/changeLog.xml
+++ b/store/src/main/resources/db/changeLog.xml
@@ -41,4 +41,34 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="4" author="versioning">
+        <createTable tableName="file_version">
+            <column name="id" type="varchar(50)">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="node_id" type="varchar(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="node_name" type="varchar(255)"/>
+            <column name="content" type="varchar(255)"/>
+            <column name="mimetype" type="varchar(50)"/>
+            <column name="size" type="bigint"/>
+            <column name="author" type="varchar(250)"/>
+            <column name="comment" type="text"/>
+            <column name="created_at" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+            <column name="version_number" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <createIndex tableName="file_version" indexName="idx_fv_node_id">
+            <column name="node_id"/>
+        </createIndex>
+        <createIndex tableName="file_version" indexName="idx_fv_node_created">
+            <column name="node_id"/>
+            <column name="created_at"/>
+        </createIndex>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## Summary

Implements file versioning for issue #11:

- **Backend**: `file_version` table (Liquibase), JPA entity, `VersioningService` CRUD, REST endpoint `/api/versions`, fix `DataStoreBean.delete()` and node remove+flush race
- **Frontend**: versioning module with auto-versioning hook, version history panel, restore/confirm modals, i18n (EN/FR)
- **Infra**: docker socket config, vite react dedupe

## Test plan

- [ ] Upload a file → verify a version v1 is created automatically
- [ ] Re-upload the same file → confirm update modal appears, new version v2 created
- [ ] Open history panel → verify versions are listed with date/author
- [ ] Preview a version → opens in new tab
- [ ] Restore a previous version → confirm modal, new version created, toast displayed
- [ ] Delete a version via API → verify it is removed from history

Closes #11